### PR TITLE
Finger friendly closes #2 #3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/example/index.html
+++ b/example/index.html
@@ -10,16 +10,17 @@
       }
 
       #wrapper {
-        width: 1024px;
+        max-width: 1024px;
         margin: 0 auto;
         padding-top: 30px;
       }
 
       #selected-text {
-        width: 200px;
+        width: 100%;
         height: 30px;
         padding: 5px;
         border: 1px solid #CCC;
+        box-sizing: border-box;
       }
     </style>
   </head>
@@ -38,7 +39,7 @@
         <p>Mei eleifend gubergren consetetur at, ea mea nonumes consequuntur. Mea at velit detracto, usu persius efficiantur no. Gubergren mnesarchum mea ex. Quidam option civibus ei sea.</p>
       </div>
     </div>
-    <script src="../src/selecting.min.js"></script>
+    <script src="../src/selecting.js"></script>
     <script>
         var $ = function(value) {
           return document.querySelectorAll(value);

--- a/example/index.html
+++ b/example/index.html
@@ -39,8 +39,6 @@
     </div>
     <script src="../src/selecting.min.js"></script>
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
-
         var $ = function(value) {
           return document.querySelectorAll(value);
         };
@@ -48,8 +46,6 @@
         window.selecting($('.container'), function(selector) {
           $('#selected-text')[0].value = selector;
         });
-
-      }, false);
     </script>
   </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -45,7 +45,7 @@
           return document.querySelectorAll(value);
         };
 
-        window.SelectingText($('.container'), function(selector) {
+        window.selecting($('.container'), function(selector) {
           $('#selected-text')[0].value = selector;
         });
 

--- a/example/index.html
+++ b/example/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Example - Selecting</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       * {
         font: 14px Arial, Verdana, sans-serif;

--- a/src/selecting.js
+++ b/src/selecting.js
@@ -21,7 +21,7 @@
     return typeof element === 'object' &&
            /^\[object (HTMLCollection|NodeList|Object)\]$/.test(stringRepr) &&
            element.hasOwnProperty('length') &&
-           (element.length === 0 || (typeof element[0] === 'object' && 
+           (element.length === 0 || (typeof element[0] === 'object' &&
            element[0].nodeType > 0));
   };
 
@@ -67,7 +67,7 @@
 
       var text = _getSelection ? doc.getSelection() :
                  selection.createRange().text;
-      
+
       callback(text);
     };
 
@@ -82,5 +82,5 @@
 
     selectText(element, callback, hasLib);
   };
-  
+
 }(window, document));

--- a/src/selecting.js
+++ b/src/selecting.js
@@ -43,12 +43,23 @@
 
   var bind = function(element, callback, hasLib) {
     if (hasLib) {
-      element.on('mouseup', debounce(callback, 150));
+      if ('ontouchstart' in window) {
+        element.each(function () {
+          checkForSelections(this, callback);
+        });
+      } else {
+        element.on('mouseup', debounce(callback, 150));
+      }
+
       return;
     }
 
     var bindDOM = function(el) {
-      el.addEventListener('mouseup', debounce(callback, 150), false);
+      if ('ontouchstart' in window) {
+        checkForSelections(el, callback);
+      } else {
+        el.addEventListener('mouseup', debounce(callback, 150), false);
+      }
     };
 
     if (!isNodeList(element)) {
@@ -61,17 +72,82 @@
     });
   };
 
-  var selectText = function(element, callback, hasLib) {
-    var onMouseUp = function(e) {
-      e.preventDefault();
+  // source http://stackoverflow.com/a/5379408
+  function getText() {
+    var text = '';
+    if (window.getSelection) {
+      text = window.getSelection().toString();
+    } else if (document.selection && document.selection.type !== 'Control') {
+      text = document.selection.createRange().text;
+    }
+    return text;
+  }
 
-      var text = _getSelection ? doc.getSelection() :
-                 selection.createRange().text;
+  var selectText = function(element, callback, hasLib) {
+    var onMouseUp = function() {
+
+      var text = getText();
 
       callback(text);
     };
 
     bind(element, onMouseUp, hasLib);
+  };
+
+  /*
+    This function detect text selection during a long-press in the screen
+  */
+  var checkForSelections = function (element, callback) {
+    var intervalCheckingForText;
+
+    var selectionStart = function () {
+
+      element.removeEventListener('touchend', selectionEnd, false);
+      element.addEventListener('touchend', selectionEnd, false);
+
+      if (intervalCheckingForText) {
+        clearInterval(intervalCheckingForText);
+      }
+
+      intervalCheckingForText = setInterval(function () {
+        var text = getText();
+
+        if (text !== '') {
+          callback(text);
+
+          selectionEnd();
+
+          checkForChanges(callback);
+        }
+      }, 100);
+    };
+
+    var selectionEnd = function () {
+      clearInterval(intervalCheckingForText);
+      element.removeEventListener('touchend', selectionEnd, false);
+    };
+
+    element.addEventListener('touchstart', selectionStart, false);
+  };
+
+  /*
+    Once this function is called, it'll check for changes in the
+    current selection string with a setInterval
+    Once the selected string is equal '', we stop the setInterval
+  */
+  var checkForChanges = function (callback) {
+    var intervalCheckingForText;
+    var currentText = getText();
+
+    intervalCheckingForText = setInterval(function () {
+      if (getText() !== currentText) {
+        callback(getText());
+        currentText = getText();
+
+      } else if (getText() === '') {
+        clearInterval(intervalCheckingForText);
+      }
+    }, 100);
   };
 
   global.selecting = function(element, callback) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -19,7 +19,7 @@ describe('selecting', function(){
       var firstElement = mockElement();
       var secondElement = mockElement();
       var container = document.getElementById('container-test');
-      
+
       container.appendChild(firstElement);
       container.appendChild(secondElement);
     };


### PR DESCRIPTION
The commit you need to check is this one https://github.com/felquis/selecting/commit/c8e673454834b8818e2fc91d653f39580f4075b0 the other is just small improvements

Well, I made a research about selecting text on touchable devices, since this plugin wasn't working properly on touches devices, so I tested in Android and iPad, and the selection spend about 700ms to select a texting, so the user must hold the finger on the screen for about 700ms to select a text.

I made this script to start checking for text selection when the use put the finger on the screen (touchstart), we start a setInterval, and is some text is selected, we stop the setInterval because the user successfully selected text. But, once the user select the first work with a tab-hold event. We aren't able to detect for changes in the current text selection, so for this reason I need to setup another setInterval, the will look for changes in the current selected text, and every time we notice some change in the selected text we fired the callback.

Still some work to do, It is hard to example all the problems, but I think this is a beginning, it merged, I'll create some issues

Tested on Android (Chrome 39) iPad,iOS8.1 (Chrome/Safari) 