### PR TITLE
Add wordCount property closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Then you can call <code>window.selecting</code> function passing two parameters:
 
 ```js
   window.selecting($('.container'), function(selector) {
-    ...
+    // Properties
+    selector.text; // The selected text
+    selector.wordCount; // The number of words selected
   });
 ```
 

--- a/example/index.html
+++ b/example/index.html
@@ -38,6 +38,10 @@
         <p>Copiosae facilisis at eam, voluptaria omittantur vim an. Mei efficiendi omittantur eu, duo eu nobis mucius, sententiae scribentur in nam. Ornatus vivendo nam et. Alia facilisi oportere quo no.</p>
         <p>Mei eleifend gubergren consetetur at, ea mea nonumes consequuntur. Mea at velit detracto, usu persius efficiantur no. Gubergren mnesarchum mea ex. Quidam option civibus ei sea.</p>
       </div>
+
+      <div class="selection-meta">
+        <span class="word-count"></span>
+      </div>
     </div>
     <script src="../src/selecting.js"></script>
     <script>
@@ -47,6 +51,7 @@
 
         window.selecting($('.container'), function(selector) {
           $('#selected-text')[0].value = selector.text;
+          $('.word-count')[0].innerHTML = selector.wordCount;
         });
     </script>
   </body>

--- a/src/selecting.js
+++ b/src/selecting.js
@@ -55,8 +55,14 @@
       var getText = this.getText;
 
       this[ this.isTouch ? 'bindTouch' : 'bindMouseUp' ](function(event) {  
+        var text = getText(),
+            // Transform 'a   a' into 'a a'
+            removeSpaces = text.replace(/\s+(?=\s)/g,''),
+            wordCount = (text !== '')? removeSpaces.split(' ').length : 0;
+
         callback({
-          'text': getText(),
+          'text': text,
+          'wordCount': wordCount,
           'event': event
         });
       });


### PR DESCRIPTION
It's a basic functionality, and should be reviewed, there's a kind of
bug already, if the user select something like ', a', wordCount will
return two words selected, but, actually there's just one word in this
string. We should remove punctuation and other characters that ins't a
word.

But, it's working.